### PR TITLE
ci: remove Node.js setup and frontend build from workflow

### DIFF
--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -27,13 +27,6 @@ jobs:
         pip install
         build
         --user
-    - uses: actions/setup-node@v4
-      with:
-        node-version-file: '.nvmrc'
-    - name: Install dependencies
-      run: npm install
-    - name: Build client
-      run: webpack --mode production
 
     - name: Build a binary wheel and a source tarball
       run: >-


### PR DESCRIPTION
- Should prevent failing of GH action because of missing .nvmrc. 

@fsbraun : webpack is not needed so we can safely remove node from the build pipeline?