### PR TITLE
fix: Enable caching for placeholder serialization and rendering.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ read-only, REST/JSON API. It is based on the django rest framework (DRF) and sup
 🌍 **Internationalization (i18n)** – Supports available CMS languages<br>
 🌲 **Structured page tree** – Fetch the full page tree with metadata<br>
 📚 **Paginated page listing** – Retrieve pages as a list with pagination support<br>
+🔄 **Built-in caching** - Uses django cache backend for placeholder serialization/rendering<br>
 👀 **Preview support** – Access draft content using `djangocms-versioning` supporting
 permissions for authenticated staff user<br>
 🧬 **Typed API schema** – Auto-generate OpenAPI schemas for pages and plugins with
@@ -69,8 +70,6 @@ projects, this is often not the case.
 
 - Inline editing and content preview are currently only available in a structured view. (Solutions
   are currently being evaluated).
-- API-Caching has yet to be addressed properly and should be handled in the frontend app for the
-  time being.
 - Not all features of a standard Django CMS are available through the API (eg. templates and tags).
 - The API focuses on fetching plugin content and page structure as JSON data.
 - Website rendering is entirely decoupled and must be implemented in the frontend framework.
@@ -181,6 +180,18 @@ INSTALLED_APPS = [
     'rest_framework',
     ...
 ]
+```
+
+```python
+# Enabled Caching
+CONTENT_CACHE_DURATION = 60  # Overwrites default from django CMS
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',  # use redis/memcached etc.
+        'LOCATION': 'unique-snowflake',
+        'TIMEOUT': CONTENT_CACHE_DURATION,  # change accordingly
+    }
+}
 ```
 
 Add the API endpoints to your project's `urls.py`:

--- a/djangocms_rest/serializers/placeholders.py
+++ b/djangocms_rest/serializers/placeholders.py
@@ -22,12 +22,9 @@ class PlaceholderRenderer(BaseRenderer):
             return False
         if self.request.user.is_staff:
             return False
-        # return True
-        # breaks fetching the placeholder content, caching implementation is not working as expected
-        # Reduce complexity and replace API caching with redis caching
-        return False
+        return True
 
-    def render_placeholder(self, placeholder, context, language, use_cache=False):
+    def render_placeholder(self, placeholder, context, language, use_cache=True):
         context.update({"request": self.request})
         if use_cache and placeholder.cache_placeholder:
             use_cache = self.placeholder_cache_is_enabled()

--- a/djangocms_rest/serializers/utils/cache.py
+++ b/djangocms_rest/serializers/utils/cache.py
@@ -55,7 +55,8 @@ def set_placeholder_rest_cache(placeholder, lang, site_id, content, request):
         get_cms_setting("CACHE_DURATIONS")["content"],
         placeholder.get_cache_expiration(request, datetime.now()),
     )
-    cache.set(key, content, duration)
+    cache.set(key, {"content": content}, duration)
+
     # "touch" the cache-version, so that it stays as fresh as this content.
     version, vary_on_list = _get_placeholder_cache_version(placeholder, lang, site_id)
     _set_placeholder_cache_version(placeholder, lang, site_id, version, vary_on_list, duration=duration)

--- a/djangocms_rest/serializers/utils/render.py
+++ b/djangocms_rest/serializers/utils/render.py
@@ -36,7 +36,7 @@ def render_html(request, placeholder, language):
         placeholder,
         context=context,
         language=language,
-        use_cache=False,
+        use_cache=True,
     )
     sekizai_blocks = context[get_varname()]
 

--- a/tests/endpoints/test_cache.py
+++ b/tests/endpoints/test_cache.py
@@ -1,0 +1,201 @@
+from cms.api import add_plugin
+from cms.models import PageContent
+from django.contrib.contenttypes.models import ContentType
+from django.contrib.sites.shortcuts import get_current_site
+from django.core.cache import cache
+
+
+from rest_framework.reverse import reverse
+
+from djangocms_rest.serializers.utils.cache import get_placeholder_rest_cache
+from tests.base import BaseCMSRestTestCase
+
+
+
+class CachingAPITestCase(BaseCMSRestTestCase):
+    @classmethod
+    def setUpClass(cls):
+        """
+        Set up test data for cache testing, using existing pages from BaseCMSRestTestCase.
+        """
+        super().setUpClass()
+        # Use the first page created in BaseCMSRestTestCase
+        cls.page = cls.pages[0]
+        cls.page_content = PageContent.objects.get(page=cls.page, language="en")
+        cls.page_content_type = ContentType.objects.get(model="pagecontent")
+        cls.placeholder = cls.page.get_placeholders(language="en").get(slot="content")
+
+        # Add a plugin to the placeholder for testing
+        cls.plugin = add_plugin(
+            placeholder=cls.placeholder,
+            plugin_type="TextPlugin",
+            language="en",
+            body="<p>Cache test content</p>",
+        )
+
+    def setUp(self):
+        """Clear the cache before each test"""
+        cache.clear()
+
+    def get_placeholder_url(self):
+        """Helper to generate the placeholder URL"""
+        return reverse(
+            "placeholder-detail",
+            kwargs={
+                "language": "en",
+                "content_type_id": self.page_content_type.id,
+                "object_id": self.page_content.id,
+                "slot": "content",
+            },
+        )
+
+    def test_cache_hit_and_miss(self):
+        """
+        Test the cache hit-and-miss functionality:
+        1. The first request should miss the cache and store content
+        2. The second request should hit the cache and return the same content
+        3. After clearing the cache, the request should miss again
+        """
+
+        # Request #1 - should miss cache
+        response1 = self.client.get(self.get_placeholder_url())
+        self.assertEqual(response1.status_code, 200)
+        placeholder1 = response1.json()
+
+        # Request #1 - Check if the cache contains our content
+        cached_content = get_placeholder_rest_cache(
+            self.placeholder, lang="en", site_id=get_current_site(None).pk, request=None
+        )
+        self.assertIsNotNone(
+            cached_content, "Cache was not populated after first request"
+        )
+
+        # Request #1 - Modify content but don't invalidate cache (testing if cache is used)
+        self.plugin.body = "<p>Updated content that should not appear while cached</p>"
+        self.plugin.save()
+
+        # Request #2 - should hit cache
+        response2 = self.client.get(self.get_placeholder_url())
+        self.assertEqual(response2.status_code, 200)
+        placeholder2 = response2.json()
+
+        # Request #2 - Responses should be identical (using cached content)
+        self.assertEqual(
+            placeholder1, placeholder2, "Responses differ - cache might not be working"
+        )
+
+        # Request #3 - Clear cache and verify we get fresh content
+        cache.clear()
+        response3 = self.client.get(self.get_placeholder_url())
+        self.assertEqual(response3.status_code, 200)
+        placeholder3 = response3.json()
+
+        # Request #3 - Content should be different after cache cleared (should contain updated text)
+        self.assertNotEqual(
+            placeholder1["content"],
+            placeholder3["content"],
+            "After clearing cache, content should be different",
+        )
+
+        # Request #3 - Verify the updated content is present in the response
+        self.assertIn("Updated content", placeholder3["content"][0]["body"])
+
+    def test_staff_bypass_cache(self):
+        """
+        Test that staff users bypass the cache:
+        1. Anonymous user request populates cache
+        2. Content is updated
+        3. Staff user should see updated content (bypass cache)
+        4. Anonymous user should still see cached content
+        """
+
+        # Anonymous request #1 - Populate cache
+        response1 = self.client.get(self.get_placeholder_url())
+        self.assertEqual(response1.status_code, 200)
+        placeholder1 = response1.json()
+
+        # Anonymous request #1 - Update content
+        original_content = self.plugin.body
+        self.plugin.body = "<p>Staff should see this content</p>"
+        self.plugin.save()
+
+        # Staff request #2 - Bypass cache
+        self.client.force_login(self.user)
+        response2 = self.client.get(self.get_placeholder_url())
+        self.assertEqual(response2.status_code, 200)
+        placeholder2 = response2.json()
+
+        # Staff request #2 - Update content
+        self.assertIn("Staff should see this content", placeholder2["content"][0]["body"])
+        self.assertNotEqual(
+            placeholder1["content"],
+            placeholder2["content"],
+            "Staff user should bypass cache and see updated content"
+        )
+
+        # Anonymous request #3 - fetch content from request #1
+        self.client.logout()
+        response3 = self.client.get(self.get_placeholder_url())
+        self.assertEqual(response3.status_code, 200)
+        placeholder3 = response3.json()
+        self.assertEqual(
+            placeholder1,
+            placeholder3,
+            "Anonymous user should still get cached content"
+        )
+
+        # Restore content
+        self.plugin.body = original_content
+        self.plugin.save()
+
+
+    def test_cache_version_edge_cases(self):
+        """
+        Test edge cases in cache version functions to improve code coverage.
+        """
+        from djangocms_rest.serializers.utils.cache import (
+            _get_placeholder_cache_version,
+            _set_placeholder_cache_version,
+        )
+        from django.core.cache import cache
+        from django.contrib.sites.shortcuts import get_current_site
+
+        # Clear the cache to start with a clean state
+        cache.clear()
+
+        # Test _get_placeholder_cache_version with no cached data (should create new)
+        version1, vary_list1 = _get_placeholder_cache_version(
+            self.placeholder, "en", get_current_site(None).pk
+        )
+        self.assertIsNotNone(version1)
+        self.assertEqual(vary_list1, [])
+
+        # Test _set_placeholder_cache_version with None version (should create new)
+        _set_placeholder_cache_version(
+            self.placeholder, "en", get_current_site(None).pk, None
+        )
+        version2, vary_list2 = _get_placeholder_cache_version(
+            self.placeholder, "en", get_current_site(None).pk
+        )
+        self.assertIsNotNone(version2)
+        self.assertNotEqual(version1, version2)  # Should be a new timestamp
+
+        # Test _set_placeholder_cache_version with negative version (should create new)
+        _set_placeholder_cache_version(
+            self.placeholder, "en", get_current_site(None).pk, -1
+        )
+        version3, vary_list3 = _get_placeholder_cache_version(
+            self.placeholder, "en", get_current_site(None).pk
+        )
+        self.assertIsNotNone(version3)
+        self.assertNotEqual(version2, version3)  # Should be a new timestamp
+
+        # Test _set_placeholder_cache_version with None vary_on_list
+        _set_placeholder_cache_version(
+            self.placeholder, "en", get_current_site(None).pk, 12345, None
+        )
+        version4, vary_list4 = _get_placeholder_cache_version(
+            self.placeholder, "en", get_current_site(None).pk
+        )
+        self.assertEqual(version4, 12345)
+        self.assertEqual(vary_list4, []) 

--- a/tests/endpoints/test_languages.py
+++ b/tests/endpoints/test_languages.py
@@ -1,6 +1,7 @@
 from rest_framework.reverse import reverse
 
 from tests.base import BaseCMSRestTestCase
+from tests.types import LANGUAGE_FIELD_TYPES
 
 
 class LanguagesAPITestCase(BaseCMSRestTestCase):
@@ -19,14 +20,7 @@ class LanguagesAPITestCase(BaseCMSRestTestCase):
 
         languages = get_cms_setting("LANGUAGES")[1]
 
-        type_checks = {
-            "code": str,
-            "name": str,
-            "public": bool,
-            "redirect_on_fallback": bool,
-            "fallbacks": list,
-            "hide_untranslated": bool
-        }
+        type_checks = LANGUAGE_FIELD_TYPES
 
         # GET
         response = self.client.get(reverse("language-list"))

--- a/tests/endpoints/test_page_detail.py
+++ b/tests/endpoints/test_page_detail.py
@@ -1,6 +1,7 @@
 from rest_framework.reverse import reverse
 
 from tests.base import BaseCMSRestTestCase
+from tests.types import PAGE_CONTENT_FIELD_TYPES
 from tests.utils import assert_field_types
 
 
@@ -19,27 +20,7 @@ class PageDetailAPITestCase(BaseCMSRestTestCase):
         - Response structure matches API contract
         """
 
-        type_checks = {
-            "title": str,
-            "page_title": str,
-            "menu_title": str,
-            "meta_description": (str, type(None)),
-            "redirect": (str, type(None)),
-            "in_navigation": bool,
-            "soft_root": bool,
-            "template": str,
-            "xframe_options": (int, str),
-            "limit_visibility_in_menu": (str, type(None)),
-            "language": str,
-            "path": str,
-            "absolute_url": str,
-            "is_home": bool,
-            "languages": list,
-            "is_preview": bool,
-            "creation_date": str,
-            "changed_date": str,
-            "placeholders": list,
-        }
+        type_checks = PAGE_CONTENT_FIELD_TYPES
 
         # GET
         response = self.client.get(reverse("page-detail", kwargs={"language": "en", "path": "page-0"}))

--- a/tests/endpoints/test_page_list.py
+++ b/tests/endpoints/test_page_list.py
@@ -3,6 +3,7 @@ from django.contrib.sites.models import Site
 from rest_framework.reverse import reverse
 
 from tests.base import BaseCMSRestTestCase
+from tests.types import PAGE_META_FIELD_TYPES
 from tests.utils import assert_field_types
 
 
@@ -26,26 +27,7 @@ class PageListAPITestCase(BaseCMSRestTestCase):
             language="en", page__site=site
         ).count()
 
-        type_checks = {
-            "title": str,
-            "page_title": str,
-            "menu_title": str,
-            "meta_description": (str, type(None)),
-            "redirect": (str, type(None)),
-            "in_navigation": bool,
-            "soft_root": bool,
-            "template": str,
-            "xframe_options": (int, str),
-            "limit_visibility_in_menu": (str, type(None)),
-            "language": str,
-            "path": str,
-            "absolute_url": str,
-            "is_home": bool,
-            "languages": list,
-            "is_preview": bool,
-            "creation_date": str,
-            "changed_date": str,
-        }
+        type_checks = PAGE_META_FIELD_TYPES
 
         # GET
         response = self.client.get(reverse("page-list", kwargs={"language": "en"}))

--- a/tests/endpoints/test_page_root.py
+++ b/tests/endpoints/test_page_root.py
@@ -1,6 +1,7 @@
 from rest_framework.reverse import reverse
 
 from tests.base import BaseCMSRestTestCase
+from tests.types import PAGE_CONTENT_FIELD_TYPES
 from tests.utils import assert_field_types
 
 
@@ -19,27 +20,7 @@ class PageRootAPITestCase(BaseCMSRestTestCase):
         - Response structure matches API contract
         """
 
-        type_checks = {
-            "title": str,
-            "page_title": str,
-            "menu_title": str,
-            "meta_description": (str, type(None)),
-            "redirect": (str, type(None)),
-            "in_navigation": bool,
-            "soft_root": bool,
-            "template": str,
-            "xframe_options": (int, str),
-            "limit_visibility_in_menu": (str, type(None)),
-            "language": str,
-            "path": str,
-            "absolute_url": str,
-            "is_home": bool,
-            "languages": list,
-            "is_preview": bool,
-            "creation_date": str,
-            "changed_date": str,
-            "placeholders": list,
-        }
+        type_checks = PAGE_CONTENT_FIELD_TYPES
 
         # GET
         response = self.client.get(reverse("page-root", kwargs={"language": "en"}))

--- a/tests/endpoints/test_page_tree_list.py
+++ b/tests/endpoints/test_page_tree_list.py
@@ -1,6 +1,7 @@
 from rest_framework.reverse import reverse
 
 from tests.base import BaseCMSRestTestCase
+from tests.types import PAGE_TREE_META_FIELD_TYPES
 from tests.utils import assert_field_types
 
 
@@ -18,27 +19,7 @@ class PageTreeListAPITestCase(BaseCMSRestTestCase):
         - Invalid language code returns 404
         """
 
-        type_checks = {
-            "title": str,
-            "page_title": str,
-            "menu_title": str,
-            "meta_description": (str, type(None)),
-            "redirect": (str, type(None)),
-            "in_navigation": bool,
-            "soft_root": bool,
-            "template": str,
-            "xframe_options": (int, str),
-            "limit_visibility_in_menu": (str, type(None)),
-            "language": str,
-            "path": str,
-            "absolute_url": str,
-            "is_home": bool,
-            "languages": list,
-            "is_preview": bool,
-            "creation_date": str,
-            "changed_date": str,
-            "children": list,
-        }
+        type_checks = PAGE_TREE_META_FIELD_TYPES
 
         # GET
         response = self.client.get(reverse("page-tree-list", kwargs={"language": "en"}))

--- a/tests/endpoints/test_placeholders.py
+++ b/tests/endpoints/test_placeholders.py
@@ -4,6 +4,7 @@ from django.contrib.contenttypes.models import ContentType
 from rest_framework.reverse import reverse
 
 from tests.base import BaseCMSRestTestCase
+from tests.types import PLACEHOLDER_FIELD_TYPES
 from tests.utils import assert_field_types
 
 
@@ -61,13 +62,7 @@ class PlaceholdersAPITestCase(BaseCMSRestTestCase):
         - Content list contains valid plugin data
         """
 
-        type_checks = {
-            "slot": str,
-            "label": str,
-            "language": str,
-            "content": list,
-            "html": str, #optional, ?html=1
-        }
+        type_checks = PLACEHOLDER_FIELD_TYPES
 
         plugin_type_checks = {
             "plugin_type": str,

--- a/tests/endpoints/test_plugin_list.py
+++ b/tests/endpoints/test_plugin_list.py
@@ -1,18 +1,14 @@
 from rest_framework.reverse import reverse
 
 from tests.base import BaseCMSRestTestCase
+from tests.types import PLUGIN_FIELD_TYPES
 from tests.utils import assert_field_types
 
 
 class PluginListTestCase(BaseCMSRestTestCase):
     def test_get(self):
 
-        type_checks = {
-            "plugin_type": str,
-            "title": str,
-            "type": str,
-            "properties": dict,
-        }
+        type_checks = PLUGIN_FIELD_TYPES
 
         # GET
         response = self.client.get(reverse("plugin-list"))

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -157,6 +157,15 @@ DATABASES = {
     }
 }
 
+CONTENT_CACHE_DURATION = 60
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+        'LOCATION': 'unique-snowflake',
+        'TIMEOUT': CONTENT_CACHE_DURATION,
+    }
+}
+
 ROOT_URLCONF = 'tests.urls'
 
 STATIC_URL = '/static/'

--- a/tests/types.py
+++ b/tests/types.py
@@ -1,0 +1,53 @@
+"""
+Type definitions used across multiple test files.
+Contains expected field structures, type mappings, and validation schemas.
+"""
+
+# API Response Type Definitions
+PAGE_META_FIELD_TYPES = {
+    "title": str,
+    "page_title": str,
+    "menu_title": str,
+    "meta_description": (str, type(None)),
+    "redirect": (str, type(None)),
+    "in_navigation": bool,
+    "soft_root": bool,
+    "template": str,
+    "xframe_options": (int, str),
+    "limit_visibility_in_menu": (str, type(None)),
+    "language": str,
+    "path": str,
+    "absolute_url": str,
+    "is_home": bool,
+    "languages": list,
+    "is_preview": bool,
+    "creation_date": str,
+    "changed_date": str,
+}
+
+PAGE_CONTENT_FIELD_TYPES = {**PAGE_META_FIELD_TYPES, "placeholders": list}
+
+PAGE_TREE_META_FIELD_TYPES = {**PAGE_META_FIELD_TYPES, "children": list}
+
+LANGUAGE_FIELD_TYPES = {
+    "code": str,
+    "name": str,
+    "public": bool,
+    "redirect_on_fallback": bool,
+    "fallbacks": list,
+    "hide_untranslated": bool,
+}
+
+PLACEHOLDER_FIELD_TYPES = {
+    "slot": str,
+    "label": str,
+    "language": str,
+    "content": list,
+}
+
+PLUGIN_FIELD_TYPES = {
+    "plugin_type": str,
+    "title": str,
+    "type": str,
+    "properties": dict,
+}


### PR DESCRIPTION
- Fix to enable caching via use_cache parameter in render_placeholder
- Added django CACHES settings for test env
- Updated README.md

Manually tested (not intensive) caching behavior with the use of a local timer = ok.