### PR TITLE
Fix/open api schema validation

### DIFF
--- a/djangocms_rest/serializers/pages.py
+++ b/djangocms_rest/serializers/pages.py
@@ -106,9 +106,9 @@ class PageMetaSerializer(BasePageSerializer, BasePageContentMixin):
             parent = instance.page.parent
             tree.setdefault(parent, []).append(instance)
 
-        # Prepare the child serializer with proper context.
+        # Prepare the child serializer with the proper context.
         kwargs["child"] = cls(context=context)
-        return PageTreeSerializer(tree, context=context, *args[1:], **kwargs)
+        return PageTreeSerializer(tree, *args[1:], **kwargs)
 
     def to_representation(self, page_content: PageContent) -> Dict:
         return self.get_base_representation(page_content)

--- a/djangocms_rest/serializers/pages.py
+++ b/djangocms_rest/serializers/pages.py
@@ -12,18 +12,21 @@ class BasePageSerializer(serializers.Serializer):
     page_title = serializers.CharField(max_length=255)
     menu_title = serializers.CharField(max_length=255)
     meta_description = serializers.CharField()
-    redirect = serializers.CharField(max_length=2048)
-    absolute_url = serializers.URLField(max_length=200)
-    placeholders: PlaceholderRelationSerializer()
+    redirect = serializers.CharField(max_length=2048, allow_null=True)
+    absolute_url = serializers.URLField(max_length=200, allow_blank=True)
     path = serializers.CharField(max_length=200)
     is_home = serializers.BooleanField()
     in_navigation = serializers.BooleanField()
     soft_root = serializers.BooleanField()
     template = serializers.CharField(max_length=100)
-    xframe_options = serializers.CharField(max_length=50)
-    limit_visibility_in_menu = serializers.BooleanField()
+    xframe_options = serializers.CharField(max_length=50, allow_blank=True)
+    limit_visibility_in_menu = serializers.BooleanField(default=False, allow_null=True)
     language = serializers.CharField(max_length=10)
     languages = serializers.ListSerializer(child=serializers.CharField(), allow_empty=True, required=False)
+    is_preview = serializers.BooleanField(default=False)
+    creation_date = serializers.DateTimeField()
+    changed_date = serializers.DateTimeField()
+
 
 class PreviewMixin:
     """Mixin to mark content as preview"""
@@ -34,7 +37,9 @@ class PreviewMixin:
 class BasePageContentMixin:
     def get_base_representation(self, page_content: PageContent) -> Dict:
         relative_url = page_content.page.get_path(page_content.language)
-        absolute_url = page_content.page.get_absolute_url(page_content.language)
+        absolute_url = page_content.page.get_absolute_url(page_content.language) or ""
+        xframe_options = str(page_content.xframe_options or "")
+        limit_visibility_in_menu = bool(page_content.limit_visibility_in_menu)
 
         return {
             "title": page_content.title,
@@ -45,8 +50,8 @@ class BasePageContentMixin:
             "in_navigation": page_content.in_navigation,
             "soft_root": page_content.soft_root,
             "template": page_content.template,
-            "xframe_options": page_content.xframe_options,
-            "limit_visibility_in_menu": page_content.limit_visibility_in_menu,
+            "xframe_options": xframe_options,
+            "limit_visibility_in_menu": limit_visibility_in_menu,
             "language": page_content.language,
             "path": relative_url,
             "absolute_url": absolute_url,
@@ -110,6 +115,8 @@ class PageMetaSerializer(BasePageSerializer, BasePageContentMixin):
 
 
 class PageContentSerializer(BasePageSerializer, BasePageContentMixin):
+    placeholders = PlaceholderRelationSerializer(many=True, required=False)
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.request = self.context.get("request")
@@ -141,6 +148,7 @@ class PageContentSerializer(BasePageSerializer, BasePageContentMixin):
 
 class PreviewPageContentSerializer(PageContentSerializer, PreviewMixin):
     """Serializer specifically for preview/draft page content"""
+    placeholders = PlaceholderRelationSerializer(many=True, required=False)
 
     def to_representation(self, page_content: PageContent) -> Dict:
         # Get placeholders directly from the page_content

--- a/tests/endpoints/test_page_tree_list.py
+++ b/tests/endpoints/test_page_tree_list.py
@@ -1,5 +1,6 @@
 from rest_framework.reverse import reverse
 
+from djangocms_rest.serializers.pages import PageMetaSerializer, PageTreeSerializer
 from tests.base import BaseCMSRestTestCase
 from tests.types import PAGE_TREE_META_FIELD_TYPES
 from tests.utils import assert_field_types
@@ -62,3 +63,16 @@ class PageTreeListAPITestCase(BaseCMSRestTestCase):
         self.client.force_login(self.user)
         response = self.client.get(reverse("preview-page-tree-list", kwargs={"language": "en"}))
         self.assertEqual(response.status_code, 200)
+
+    # TEST SERIALIZER EDGE CASES
+    def test_tree_serializer_type_error(self):
+        """Test that PageTreeSerializer raises TypeError when a tree is not a dict"""
+        # Create a mock dictionary with the tree parameter explicitly as a string
+        mock_kwargs = {"tree": "not_a_dict"}
+        with self.assertRaises(TypeError):
+            PageTreeSerializer(**mock_kwargs)
+
+    def test_page_meta_serializer_many_init(self):
+        """Test that PageMetaSerializer.many_init returns a PageTreeSerializer instance"""
+        serializer = PageMetaSerializer.many_init(context={})
+        self.assertIsInstance(serializer, PageTreeSerializer)

--- a/tests/types.py
+++ b/tests/types.py
@@ -13,21 +13,30 @@ PAGE_META_FIELD_TYPES = {
     "in_navigation": bool,
     "soft_root": bool,
     "template": str,
-    "xframe_options": (int, str),
-    "limit_visibility_in_menu": (str, type(None)),
+    "xframe_options": str,
+    "limit_visibility_in_menu": (bool, type(None)),
     "language": str,
     "path": str,
     "absolute_url": str,
     "is_home": bool,
     "languages": list,
     "is_preview": bool,
-    "creation_date": str,
-    "changed_date": str,
+    "creation_date": (str, "datetime"),
+    "changed_date": (str, "datetime"),
 }
 
-PAGE_CONTENT_FIELD_TYPES = {**PAGE_META_FIELD_TYPES, "placeholders": list}
-
 PAGE_TREE_META_FIELD_TYPES = {**PAGE_META_FIELD_TYPES, "children": list}
+
+PLACEHOLDER_RELATION_FIELD_TYPES = {
+    "content_type_id": int,
+    "object_id": int,
+    "slot": str,
+}
+
+PAGE_CONTENT_FIELD_TYPES = {
+    **PAGE_META_FIELD_TYPES,
+    "placeholders": [PLACEHOLDER_RELATION_FIELD_TYPES]
+}
 
 LANGUAGE_FIELD_TYPES = {
     "code": str,
@@ -43,6 +52,7 @@ PLACEHOLDER_FIELD_TYPES = {
     "label": str,
     "language": str,
     "content": list,
+    "html": str,
 }
 
 PLUGIN_FIELD_TYPES = {

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,37 +2,92 @@ from typing import Any, Dict, Tuple, Type, Union
 from unittest import TestCase
 
 
+from typing import List
+
+
 def assert_field_types(
     test_case: TestCase,
     obj: Dict[str, Any],
     field: str,
-    expected_type: Union[Type, Tuple[Type, ...]],
+    expected_type: Union[Type, Tuple[Type, ...], List, Dict],
     obj_type: str = "object"
 ):
     """
     Utility function to check if a field exists and has the correct type in an object.
+    Supports nested type checking for lists and dictionaries.
 
     Args:
         test_case: TestCase instance (self in test methods)
         obj: Dict containing the fields to check
         field: String name of the field to check
-        expected_type: Type or tuple of types that are valid for this field
+        expected_type: Type specification that can be:
+            - A type (e.g., str, int)
+            - A tuple of types (e.g., (str, None))
+            - A list with a single item that is a dict, indicating a list of objects with that structure
+            - A dict specifying the structure of a nested object
         obj_type: String describing the type of object being checked (for error messages)
     """
+    # Check if the field exists
     test_case.assertIn(
         field,
         obj,
         f"Field {field} is missing in {obj_type}"
     )
 
-    if isinstance(expected_type, tuple):
-        test_case.assertTrue(
-            isinstance(obj[field], expected_type),
-            f"Field {field} should be one of types {expected_type}, got {type(obj[field])}"
+    # Get the field value
+    field_value = obj[field]
+
+    # Handle a list of structured objects [{}]
+    if isinstance(expected_type, list) and len(expected_type) == 1 and isinstance(expected_type[0], dict):
+        # First, verify this is a list
+        test_case.assertIsInstance(
+            field_value,
+            list,
+            f"Field {field} should be a list, got {type(field_value)}"
         )
+
+        # Then verify each item in the list
+        nested_structure = expected_type[0]
+        for i, item in enumerate(field_value):
+            for nested_field, nested_type in nested_structure.items():
+                assert_field_types(
+                    test_case,
+                    item,
+                    nested_field,
+                    nested_type,
+                    f"{field}[{i}]"
+                )
+
+    # Handle dictionary of a structured object {}
+    elif isinstance(expected_type, dict):
+        # First, verify this is a dict
+        test_case.assertIsInstance(
+            field_value,
+            dict,
+            f"Field {field} should be a dictionary, got {type(field_value)}"
+        )
+
+        # Then verify each field in the dictionary
+        for nested_field, nested_type in expected_type.items():
+            assert_field_types(
+                test_case,
+                field_value,
+                nested_field,
+                nested_type,
+                field
+            )
+
+    # Handle tuple of types (type1, type2)
+    elif isinstance(expected_type, tuple):
+        test_case.assertTrue(
+            isinstance(field_value, expected_type),
+            f"Field {field} should be one of types {expected_type}, got {type(field_value)}"
+        )
+
+    # Handle basic types (str, int, etc.)
     else:
         test_case.assertIsInstance(
-            obj[field],
+            field_value,
             expected_type,
-            f"Field {field} should be {expected_type}, got {type(obj[field])}"
+            f"Field {field} should be {expected_type}, got {type(field_value)}"
         )


### PR DESCRIPTION
- Enhance OpenAPI 3 typing support 
- Validate every endpoint’s response against its OpenAPI schema (Postman tests)
- Fix/align type annotations in existing tests
- Add tests for serializers/pages.py

Fixes #32