### PR TITLE
feat: frontend URL handling with absolute URL generation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,12 @@ INSTALLED_APPS = [
 ]
 ```
 
+Set up frontend protocol and caching in your `settings.py`:
+```python
+# Set frontend protocol
+FRONTEND_PROTOCOL = 'http'  # or 'https', needed for absolute URLs in API responses
+```
+
 ```python
 # Enabled Caching
 CONTENT_CACHE_DURATION = 60  # Overwrites default from django CMS

--- a/djangocms_rest/serializers/pages.py
+++ b/djangocms_rest/serializers/pages.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional
+from typing import Dict
 
 from cms.models import PageContent
 from django.db import models

--- a/djangocms_rest/serializers/pages.py
+++ b/djangocms_rest/serializers/pages.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Dict, Optional
 
 from cms.models import PageContent
 from django.db import models
@@ -38,9 +38,10 @@ class PreviewMixin:
 
 
 class BasePageContentMixin:
-    def get_base_representation(self, page_content: PageContent) -> Dict:
+    def get_base_representation(self, page_content: PageContent, context: Optional[Dict] = None) -> Dict:
+        request = getattr(self, "request", None)
         relative_url = page_content.page.get_path(page_content.language)
-        absolute_url = get_absolute_frontend_url(relative_url)
+        absolute_url = get_absolute_frontend_url(request,relative_url)
         redirect = str(page_content.redirect or "")
         xframe_options = str(page_content.xframe_options or "")
         application_namespace = str(page_content.page.application_namespace or "")

--- a/djangocms_rest/serializers/pages.py
+++ b/djangocms_rest/serializers/pages.py
@@ -38,10 +38,10 @@ class PreviewMixin:
 
 
 class BasePageContentMixin:
-    def get_base_representation(self, page_content: PageContent, context: Optional[Dict] = None) -> Dict:
+    def get_base_representation(self, page_content: PageContent) -> Dict:
         request = getattr(self, "request", None)
-        relative_url = page_content.page.get_path(page_content.language)
-        absolute_url = get_absolute_frontend_url(request,relative_url)
+        path = page_content.page.get_path(page_content.language)
+        absolute_url = get_absolute_frontend_url(request,path)
         redirect = str(page_content.redirect or "")
         xframe_options = str(page_content.xframe_options or "")
         application_namespace = str(page_content.page.application_namespace or "")
@@ -59,7 +59,7 @@ class BasePageContentMixin:
             "xframe_options": xframe_options,
             "limit_visibility_in_menu": limit_visibility_in_menu,
             "language": page_content.language,
-            "path": relative_url,
+            "path": path,
             "absolute_url": absolute_url,
             "is_home": page_content.page.is_home,
             "login_required": page_content.page.login_required,

--- a/djangocms_rest/utils.py
+++ b/djangocms_rest/utils.py
@@ -1,4 +1,7 @@
+from typing import Optional, Union
+
 from cms.models import Page, PageUrl
+from django.conf import settings
 from django.contrib.sites.models import Site
 from django.http import Http404
 
@@ -15,3 +18,34 @@ def get_object(site: Site, path: str) -> Page:
     else:
         page.urls_cache = {url.language: url for url in page_urls}
     return page
+
+
+def get_absolute_frontend_url(path: str, site_id: Union[Site, int, str] = 1, protocol: Optional[str] = None) -> str:
+    """
+    Converts a relative path to an absolute URL using the site's domain.
+
+    Args:
+        path: The relative path to convert
+        site_id: The ID of the site or a Site object
+        protocol: The protocol to use (default is "https")
+
+    Returns:
+        A properly formatted absolute URL
+    """
+    # Return the original path if it's already an absolute URL
+    if path.startswith(("http://", "https://")):
+        return path
+
+    site = Site.objects.get(id=int(site_id))
+    domain = site.domain
+
+    # Handle start/end slashes for domain and path
+    if domain.endswith("/") and path.startswith("/"):
+        domain = domain.rstrip("/")
+    elif not domain.endswith("/") and not path.startswith("/"):
+        domain = f"{domain}/"
+
+    if protocol is None:
+        protocol = getattr(settings, "FRONTEND_PROTOCOL", "https")
+
+    return f"{protocol}://{domain}{path}"

--- a/djangocms_rest/utils.py
+++ b/djangocms_rest/utils.py
@@ -1,5 +1,3 @@
-from typing import Optional, Union
-
 from cms.models import Page, PageUrl
 from django.contrib.sites.models import Site
 from django.contrib.sites.shortcuts import get_current_site

--- a/djangocms_rest/utils.py
+++ b/djangocms_rest/utils.py
@@ -1,9 +1,9 @@
 from typing import Optional, Union
 
 from cms.models import Page, PageUrl
-from django.conf import settings
 from django.contrib.sites.models import Site
 from django.http import Http404
+from rest_framework.request import Request
 
 
 def get_object(site: Site, path: str) -> Page:
@@ -20,11 +20,12 @@ def get_object(site: Site, path: str) -> Page:
     return page
 
 
-def get_absolute_frontend_url(path: str, site_id: Union[Site, int, str] = 1, protocol: Optional[str] = None) -> str:
+def get_absolute_frontend_url(request: Request, path: str, site_id: Union[Site, int, str] = 1) -> str:
     """
     Converts a relative path to an absolute URL using the site's domain.
 
     Args:
+        request: The HTTP request object
         path: The relative path to convert
         site_id: The ID of the site or a Site object
         protocol: The protocol to use (default is "https")
@@ -45,7 +46,6 @@ def get_absolute_frontend_url(path: str, site_id: Union[Site, int, str] = 1, pro
     elif not domain.endswith("/") and not path.startswith("/"):
         domain = f"{domain}/"
 
-    if protocol is None:
-        protocol = getattr(settings, "FRONTEND_PROTOCOL", "https")
+    protocol = getattr(request, "scheme", "http")
 
     return f"{protocol}://{domain}{path}"

--- a/djangocms_rest/views.py
+++ b/djangocms_rest/views.py
@@ -115,7 +115,7 @@ class PageTreeListView(BaseAPIView):
         except PageContent.DoesNotExist:
             raise NotFound()
 
-        serializer = self.serializer_class(pages, many=True, read_only=True)
+        serializer = self.serializer_class(pages, many=True, read_only=True, context={"request": request})
         return Response(serializer.data)
 
 
@@ -134,7 +134,7 @@ class PageDetailView(BaseAPIView):
             page_content = page.get_content_obj(language, fallback=True)
             if page_content is None:
                 raise PageContent.DoesNotExist()
-            serializer = self.serializer_class(page_content, read_only=True)
+            serializer = self.serializer_class(page_content, read_only=True, context={"request": request})
             return Response(serializer.data)
         except PageContent.DoesNotExist:
             raise NotFound()
@@ -250,7 +250,7 @@ class PreviewPageView(BaseAPIView):
         except PageContent.DoesNotExist:
             raise NotFound()
 
-        serializer = self.serializer_class(page_content, read_only=True)
+        serializer = self.serializer_class(page_content, read_only=True, context={"request": request})
         return Response(serializer.data)
 
 #NOTE: This is working, but might need refactoring
@@ -279,7 +279,7 @@ class PreviewPageTreeListView(BaseAPIView):
         except PageContent.DoesNotExist:
             raise NotFound()
 
-        serializer = self.serializer_class(pages, many=True, read_only=True)
+        serializer = self.serializer_class(pages, many=True, read_only=True, context={"request": request})
         return Response(serializer.data)
 
 class PreviewPageListView(BaseListAPIView):

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -1,0 +1,55 @@
+from django.contrib.sites.models import Site
+from rest_framework.test import APIRequestFactory
+
+from djangocms_rest.utils import get_absolute_frontend_url
+from tests.base import BaseCMSRestTestCase
+
+
+class UrlUtilsTestCase(BaseCMSRestTestCase):
+    """
+    Test the get_absolute_frontend_url utility function.
+
+    Verifies:
+    - Function correctly builds absolute URLs for frontend paths
+    - Function raises proper ValueError for invalid paths
+    - Function works correctly with both a request object and None
+    - All URLs use the correct domain from a Site object
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.factory = APIRequestFactory()
+
+    def test_get_absolute_frontend_url_valid_path(self):
+        """Test that get_absolute_frontend_url works with valid paths."""
+
+        request = self.factory.get("/dummy")
+        site = Site.objects.get_current()
+        result = get_absolute_frontend_url(request, "valid/path")
+
+        # Validation
+        expected_url = f"http://{site.domain}/valid/path"
+        self.assertEqual(result, expected_url)
+
+    def test_get_absolute_frontend_url_with_leading_slash(self):
+        """Test that get_absolute_frontend_url raises ValueError with paths starting with /."""
+        request = self.factory.get("/dummy")
+
+        # Function execution and validation
+        with self.assertRaises(ValueError) as context:
+            get_absolute_frontend_url(request, "/invalid/path")
+
+        # Error message validation
+        error_message = str(context.exception)
+        self.assertIn("Path should not start with '/'", error_message)
+        self.assertIn("/invalid/path", error_message)
+
+    def test_get_absolute_frontend_url_without_request(self):
+        """Test that get_absolute_frontend_url works with request=None."""
+
+        result = get_absolute_frontend_url(None, "valid/path")
+
+        # Validation
+        site = Site.objects.get(id=1)
+        expected_url = f"http://{site.domain}/valid/path"
+        self.assertEqual(result, expected_url)

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -181,3 +181,6 @@ REST_FRAMEWORK = {
 }
 
 USE_TZ = True
+
+FRONTEND_PROTOCOL = "http" # or "https" depending on your setup
+

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -182,5 +182,3 @@ REST_FRAMEWORK = {
 
 USE_TZ = True
 
-FRONTEND_PROTOCOL = "http" # or "https" depending on your setup
-


### PR DESCRIPTION
- Fixes for the redirect and application_namespace fields, meaning the response should now properly align with the schema.
- Add absolute URL with frontend path from sites.
- Add a utils function for absolute URLs.
- Add a frontend protocol setting/default to HTTPS: protocol = getattr(settings, 'FRONTEND_PROTOCOL', 'https')

@fsbraun: In order to validate the 'absolute_url' field as a URL, we need to format the response properly as a URL; otherwise, the schema validation will fail. In combination with the frontend protocol and site, this should work. What do you think?