### PR TITLE
Feat/json edit review

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,10 @@ projects, this is often not the case.
 **Limitations and considerations in headless mode:**
 
 - Inline editing and content preview are available as JSON views on both edit and preview mode. Turn
-  JSON rendering on and of using the `REST_JSON_RENDERING` setting.
-- Not all features of a standard Django CMS are available through the API (eg. templates and tags).
+  JSON rendering on and off using the `REST_JSON_RENDERING` setting.
 - The API focuses on fetching plugin content and page structure as JSON data.
 - Website rendering is entirely decoupled and must be implemented in the frontend framework.
+- Not (yet) all features of a standard Django CMS are available through the API (eg. Menu).
 
 ## Are there js packages for drop-in support of frontend editing in the javascript framework of my choice?
 

--- a/djangocms_rest/plugin_rendering.py
+++ b/djangocms_rest/plugin_rendering.py
@@ -322,13 +322,25 @@ class RESTRenderer(ContentRenderer):
         )
 
         def serialize_children(child_plugins):
-            for plugin in child_plugins:
-                plugin_content = serialize_cms_plugin(plugin, context)
-                if getattr(plugin, "child_plugin_instances", None):
-                    plugin_content["children"] = serialize_children(
-                        plugin.child_plugin_instances
+            children_list = []
+            for child_plugin in child_plugins:
+                child_content = serialize_cms_plugin(child_plugin, context)
+                if getattr(child_plugin, "child_plugin_instances", None):
+                    child_content["children"] = serialize_children(
+                        child_plugin.child_plugin_instances
                     )
-                if plugin_content:
-                    yield plugin_content
+                if child_content:
+                    children_list.append(child_content)
+            return children_list
 
-        return list(serialize_children(plugins))
+        results = []
+        for plugin in plugins:
+            plugin_content = serialize_cms_plugin(plugin, context)
+            if getattr(plugin, "child_plugin_instances", None):
+                plugin_content["children"] = serialize_children(
+                    plugin.child_plugin_instances
+                )
+            if plugin_content:
+                results.append(plugin_content)
+        return results
+

--- a/djangocms_rest/serializers/plugins.py
+++ b/djangocms_rest/serializers/plugins.py
@@ -185,7 +185,7 @@ class PluginDefinitionSerializer(serializers.Serializer):
         """
         definitions = {}
 
-        for plugin in plugin_pool.get_all_plugins(root_plugin=False):
+        for plugin in plugin_pool.plugins.values():
             # Use plugin's serializer_class or create a simple fallback
             serializer_cls = getattr(plugin, "serializer_class", None)
 

--- a/djangocms_rest/serializers/plugins.py
+++ b/djangocms_rest/serializers/plugins.py
@@ -185,7 +185,7 @@ class PluginDefinitionSerializer(serializers.Serializer):
         """
         definitions = {}
 
-        for plugin in plugin_pool.get_all_plugins(...,root_plugin=False):
+        for plugin in plugin_pool.get_all_plugins(root_plugin=False):
             # Use plugin's serializer_class or create a simple fallback
             serializer_cls = getattr(plugin, "serializer_class", None)
 

--- a/djangocms_rest/serializers/plugins.py
+++ b/djangocms_rest/serializers/plugins.py
@@ -185,7 +185,7 @@ class PluginDefinitionSerializer(serializers.Serializer):
         """
         definitions = {}
 
-        for plugin in plugin_pool.get_all_plugins():
+        for plugin in plugin_pool.get_all_plugins(...,root_plugin=False):
             # Use plugin's serializer_class or create a simple fallback
             serializer_cls = getattr(plugin, "serializer_class", None)
 


### PR DESCRIPTION
I suggest the following fixes:
- explicitly include all plugins, also nested ones for type creation `get_all_plugins(...,root_plugin=False):`. Otherwise, I do only get top-level plugins and no definitions for nested plugins.
- Address issues with serializing cached results.

## Summary by Sourcery

Improve plugin definition and serialization to include nested plugins correctly and resolve cached serialization issues

Bug Fixes:
- Fix issues with serializing cached plugin results

Enhancements:
- Include nested plugins in plugin definitions by passing root_plugin=False to get_all_plugins
- Refactor serialize_plugins to build and return a list of plugin content with nested children instead of using a generator

Documentation:
- Correct README wording for toggling JSON rendering and update limitations note