### PR TITLE
feature/site-middleware

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
         pip install .
 
     - name: Run coverage
-      run: coverage run runtests.py
+      run: coverage run -m pytest
 
     - name: Upload Coverage to Codecov
       uses: codecov/codecov-action@v5.5.0

--- a/djangocms_rest/middleware.py
+++ b/djangocms_rest/middleware.py
@@ -1,0 +1,16 @@
+from django.contrib.sites.models import Site
+from django.http import HttpResponseServerError
+
+
+class MultiSiteMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        site_id = request.headers.get("X-Site-ID")
+        if site_id:
+            try:
+                request.site = Site.objects.get(pk=site_id)
+            except Site.DoesNotExist:
+                return HttpResponseServerError("Oops! Something went wrong.")
+        return self.get_response(request)

--- a/djangocms_rest/middleware.py
+++ b/djangocms_rest/middleware.py
@@ -1,16 +1,60 @@
+from typing import Optional
+
+from cms.utils import get_current_site
 from django.contrib.sites.models import Site
-from django.http import HttpResponseServerError
+from django.core.cache import cache
+from django.db.models.signals import post_delete, post_save
+from django.http import HttpRequest, HttpResponse, HttpResponseServerError
+from django.conf import settings
+from django.utils.deprecation import MiddlewareMixin
 
 
-class MultiSiteMiddleware:
-    def __init__(self, get_response):
-        self.get_response = get_response
+def get_site_cache_key(site_id) -> str:
+    """
+    Generate a cache key for a site ID.
+    Used by the MultiSiteMiddleware and signal handlers to invalidate the cache.
+    """
+    return f"site:{site_id}"
 
-    def __call__(self, request):
+
+class SiteContextMiddleware(MiddlewareMixin):
+    @staticmethod
+    def process_request(request: HttpRequest) -> Optional[HttpResponse]:
+        """
+        Process the request to determine the site context.
+        Cache the site object based on the site ID provided in the request headers.
+
+        Args:
+            request: The HTTP request object
+
+        Returns:
+            An HTTP response if an error occurs, None otherwise
+        """
         site_id = request.headers.get("X-Site-ID")
+
         if site_id:
             try:
-                request.site = Site.objects.get(pk=site_id)
-            except Site.DoesNotExist:
+                site_id = int(site_id)
+                cache_key = get_site_cache_key(site_id)
+                site = cache.get(cache_key)
+
+                if site is None:
+                    site = Site.objects.get(pk=site_id)
+                    cache.set(cache_key, site, settings.CONTENT_CACHE_DURATION)
+
+                request.site = site
+            except (Site.DoesNotExist, ValueError):
                 return HttpResponseServerError("Oops! Something went wrong.")
-        return self.get_response(request)
+        else:
+            request.site = get_current_site()
+        return None
+
+
+def clear_site_cache(sender, instance, **kwargs):
+    """Clear the cache for a specific site when it's modified or deleted."""
+    cache_key = get_site_cache_key(instance.pk)
+    cache.delete(cache_key)
+
+
+post_save.connect(clear_site_cache, sender=Site)
+post_delete.connect(clear_site_cache, sender=Site)

--- a/djangocms_rest/middleware.py
+++ b/djangocms_rest/middleware.py
@@ -1,55 +1,45 @@
-from typing import Optional
+from typing import Callable
 
 from django.contrib.sites.shortcuts import get_current_site
 from django.contrib.sites.models import Site
-from django.core.cache import cache
-from django.db.models.signals import post_delete, post_save
-from django.http import HttpRequest, HttpResponse, HttpResponseServerError
-from django.conf import settings
-from django.utils.deprecation import MiddlewareMixin
+from django.http import (
+    HttpRequest,
+    HttpResponse,
+    HttpResponseBadRequest,
+    HttpResponseNotFound,
+)
 
 
-def get_site_cache_key(site_id) -> str:
-    """
-    Generate a cache key for a site ID.
-    Used by the MultiSiteMiddleware and signal handlers to invalidate the cache.
-    """
-    return f"site:{site_id}"
+class SiteContextMiddleware:
+    def __init__(self, get_response: Callable[[HttpRequest], HttpResponse]):
+        self.get_response = get_response
 
-
-class SiteContextMiddleware(MiddlewareMixin):
-    @staticmethod
-    def process_request(request: HttpRequest) -> Optional[HttpResponse]:
+    def __call__(self, request: HttpRequest) -> HttpResponse:
         """
         Process the request to determine the site context.
-        Cache the site object based on the site ID provided in the request headers.
+        Sets the site object on the request based on the site ID provided in
+        the request headers or falls back to the current site.
 
         Args:
             request: The HTTP request object
 
         Returns:
-            An HTTP response if an error occurs, None otherwise
+            Optional[HttpResponse]: Either an HTTP error response if site identification
+                           fails, or None to continue down the middleware chain
         """
         site_id = request.headers.get("X-Site-ID")
 
         if site_id:
             try:
                 site_id = int(site_id)
+                # Using _get_site_by_id directly as it leverages Django's internal site caching
                 site = Site.objects._get_site_by_id(site_id)
-
                 request.site = site
-            except (Site.DoesNotExist, ValueError):
-                return HttpResponseServerError("Oops! Something went wrong.")
+            except ValueError:
+                return HttpResponseBadRequest("Invalid site ID format.")
+            except Site.DoesNotExist:
+                return HttpResponseNotFound("The requested site could not be found.")
+
         else:
             request.site = get_current_site(request)
-        return None
-
-
-def clear_site_cache(sender, instance, **kwargs):
-    """Clear the cache for a specific site when it's modified or deleted."""
-    cache_key = get_site_cache_key(instance.pk)
-    cache.delete(cache_key)
-
-
-post_save.connect(clear_site_cache, sender=Site)
-post_delete.connect(clear_site_cache, sender=Site)
+        return self.get_response(request)

--- a/djangocms_rest/middleware.py
+++ b/djangocms_rest/middleware.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from cms.utils import get_current_site
+from django.contrib.sites.shortcuts import get_current_site
 from django.contrib.sites.models import Site
 from django.core.cache import cache
 from django.db.models.signals import post_delete, post_save

--- a/djangocms_rest/middleware.py
+++ b/djangocms_rest/middleware.py
@@ -35,12 +35,7 @@ class SiteContextMiddleware(MiddlewareMixin):
         if site_id:
             try:
                 site_id = int(site_id)
-                cache_key = get_site_cache_key(site_id)
-                site = cache.get(cache_key)
-
-                if site is None:
-                    site = Site.objects.get(pk=site_id)
-                    cache.set(cache_key, site, settings.CONTENT_CACHE_DURATION)
+                site = Site.objects._get_site_by_id(site_id)
 
                 request.site = site
             except (Site.DoesNotExist, ValueError):

--- a/djangocms_rest/middleware.py
+++ b/djangocms_rest/middleware.py
@@ -46,7 +46,7 @@ class SiteContextMiddleware(MiddlewareMixin):
             except (Site.DoesNotExist, ValueError):
                 return HttpResponseServerError("Oops! Something went wrong.")
         else:
-            request.site = get_current_site()
+            request.site = get_current_site(request)
         return None
 
 

--- a/djangocms_rest/views_base.py
+++ b/djangocms_rest/views_base.py
@@ -1,6 +1,5 @@
 from django.contrib.sites.shortcuts import get_current_site
 from django.utils.functional import cached_property
-
 from rest_framework.generics import ListAPIView
 from rest_framework.views import APIView
 
@@ -17,7 +16,8 @@ class BaseAPIView(APIView):
         """
         Fetch and cache the current site and make it available to all views.
         """
-        return get_current_site(self.request)
+        site = getattr(self.request, "site", None)
+        return site if site is not None else get_current_site(self.request)
 
 
 class BaseListAPIView(ListAPIView):
@@ -30,4 +30,5 @@ class BaseListAPIView(ListAPIView):
         """
         Fetch and cache the current site and make it available to all views.
         """
-        return get_current_site(self.request)
+        site = getattr(self.request, "site", None)
+        return site if site is not None else get_current_site(self.request)

--- a/tests/middleware/test_site_context_middleware.py
+++ b/tests/middleware/test_site_context_middleware.py
@@ -1,0 +1,117 @@
+from django.urls import reverse
+
+from tests.base import BaseCMSRestTestCase
+
+from django.contrib.sites.models import Site
+from cms.api import create_page, publish_page
+
+
+class SiteContextMiddlewareTestCase(BaseCMSRestTestCase):
+    @classmethod
+    def setUpClass(cls):
+        """
+        Sets up a test environment with multiple sites.
+        """
+        super().setUpClass()
+
+        cls.site1 = Site.objects.get(id=1)
+        cls.site1.domain = "site1.example.com"
+        cls.site1.name = "Site 1"
+        cls.site1.save()
+
+        cls.site2 = Site.objects.create(domain="site2.example.com", name="Site 2")
+
+    @classmethod
+    def tearDownClass(cls):
+        """
+        Clean up the test environment and reset site 1.
+        """
+        try:
+            cls.site2.delete()
+        except Site.DoesNotExist:
+            pass
+
+        try:
+            cls.site1.domain = "example.com"
+            cls.site1.name = "example.com"
+            cls.site1.save()
+        except Site.DoesNotExist:
+            pass
+
+        super().tearDownClass()
+
+    def test_site_middleware_with_header(self):
+        """
+        Test the SiteContextMiddleware correctly handles X-Site-ID header
+        and returns different pages based on the site id.
+
+        Verifies:
+        - Middleware uses the site ID from X-Site-ID header
+        - the Same path returns different content based on site ID
+        - Invalid site ID returns appropriate error
+        - Missing site ID uses default site
+        """
+        # Create specific test pages with unique titles for each site
+        site1_test_page = create_page(
+            title="Site 1 Test Page",
+            template="page.html",
+            language="en",
+            slug="test-page",
+            site=self.site1,
+        )
+        publish_page(site1_test_page, "en", True)
+
+        site2_test_page = create_page(
+            title="Site 2 Test Page",
+            template="page.html",
+            language="en",
+            slug="test-page",
+            site=self.site2,
+        )
+        publish_page(site2_test_page, "en", True)
+
+        # Test with site 1 header
+        response = self.client.get(
+            reverse("page-detail", kwargs={"language": "en", "path": "test-page"}),
+            HTTP_X_SITE_ID="1",
+        )
+        self.assertEqual(response.status_code, 200)
+        site1_data = response.json()
+
+        # Test with site 2 header
+        response = self.client.get(
+            reverse("page-detail", kwargs={"language": "en", "path": "test-page"}),
+            HTTP_X_SITE_ID="2",
+        )
+        self.assertEqual(response.status_code, 200)
+        site2_data = response.json()
+
+        # Compare titles - these should be different
+        self.assertEqual(site1_data.get("title"), "Site 1 Test Page")
+        self.assertEqual(site2_data.get("title"), "Site 2 Test Page")
+        self.assertNotEqual(site1_data.get("title"), site2_data.get("title"))
+
+        # Test invalid site ID
+        response = self.client.get(
+            reverse("page-detail", kwargs={"language": "en", "path": "test-page"}),
+            HTTP_X_SITE_ID="999",
+        )
+        self.assertEqual(response.status_code, 404)
+
+        # Test invalid site ID format
+        response = self.client.get(
+            reverse("page-detail", kwargs={"language": "en", "path": "test-page"}),
+            HTTP_X_SITE_ID="invalid",
+        )
+        self.assertEqual(response.status_code, 400)
+
+        # Test without a site ID header (should default to site 1)
+        response = self.client.get(
+            reverse("page-detail", kwargs={"language": "en", "path": "test-page"})
+        )
+        self.assertEqual(response.status_code, 200)
+        default_data = response.json()
+
+        # Verify default site returns the same content as site 1
+        self.assertEqual(default_data.get("title"), site1_data.get("title"))
+        self.assertEqual(default_data.get("title"), "Site 1 Test Page")

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -19,9 +19,9 @@ MIGRATION_MODULES = DisableMigrations()
 SECRET_KEY = "djangocms-text-test-suite"
 
 INSTALLED_APPS = [
+    "django.contrib.sites",
     "django.contrib.contenttypes",
     "django.contrib.auth",
-    "django.contrib.sites",
     "django.contrib.sessions",
     "django.contrib.admin",
     "django.contrib.messages",

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -40,7 +40,7 @@ MIDDLEWARE = [
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
-    "djangocms_rest.middleware.MultiSiteMiddleware"
+    "djangocms_rest.middleware.SiteContextMiddleware",
     "cms.middleware.user.CurrentUserMiddleware",
     "cms.middleware.page.CurrentPageMiddleware",
     "cms.middleware.toolbar.ToolbarMiddleware",

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -40,6 +40,7 @@ MIDDLEWARE = [
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
+    "djangocms_rest.middleware.MultiSiteMiddleware"
     "cms.middleware.user.CurrentUserMiddleware",
     "cms.middleware.page.CurrentPageMiddleware",
     "cms.middleware.toolbar.ToolbarMiddleware",

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ deps =
 commands =
     {envpython} --version
     {env:COMMAND:coverage} erase
-    {env:COMMAND:coverage} run runtests.py
+    {env:COMMAND:coverage} run -m pytest
     {env:COMMAND:coverage} report
 
 [testenv:ruff]


### PR DESCRIPTION
This solves the problem of serving multiple frontend clients via one single CMS backend. 
Resolves #37 

- X-Site-ID header information has to be added in the frontend to the request, which switches the Django site for this particular request, effectively returning site-specific content.
- Support basic cache handling -> might need closer inspection/improvements

Frontend implementation is straightforward, in Nuxt:
```typescript
export default defineNuxtPlugin(() => {
  const config = useRuntimeConfig()
  client.setConfig({
    baseURL: config.public.apiBaseUrl,
    headers: {
      'X-Site-ID': config.public.siteId,
    },
  })
})
```

Alternative approach:
- Add {site_id} to all endpoints and switch sites not via middleware but in API requests. This might be a major rework. I propose middleware implementation until a more sophisticated implementation is needed. 

Note: In combination with iframe preview, we can replicate a lot of Django CMS content handling via WYSIWYG (updating iframe requests on content change is already working). Only double-click to edit and jump to anchor is not yet available, but could be doable.

## Summary by Sourcery

Support serving multiple frontend clients from a single CMS backend by switching the Django site context per request based on an X-Site-ID header and caching Site instances for efficiency

New Features:
- Introduce SiteContextMiddleware to read X-Site-ID header and attach the corresponding Site object to each request
- Update djangocms_rest view base classes to return request.site when available before falling back to the default site
- Connect Site save and delete signals to automatically clear cached Site entries

Enhancements:
- Implement basic caching of Site objects with a configurable expiration to improve performance