### PR TITLE
feat: add OpenAPI support for "preview" query parameter

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,11 @@ jobs:
       uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Install system deps (cairo stack)
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y \
+          build-essential libcairo2-dev pkg-config python3-dev
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/djangocms_rest/views.py
+++ b/djangocms_rest/views.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Callable, ParamSpec, TypeVar
 from django.contrib.sites.shortcuts import get_current_site
 from django.urls import reverse
 from django.utils.functional import lazy
@@ -32,10 +32,12 @@ from djangocms_rest.utils import (
 )
 from djangocms_rest.views_base import BaseAPIView, BaseListAPIView
 
+P = ParamSpec("P")
+T = TypeVar("T")
 
 try:
     from drf_spectacular.types import OpenApiTypes
-    from drf_spectacular.utils import OpenApiParameter, extend_schema  # noqa: F401
+    from drf_spectacular.utils import OpenApiParameter, extend_schema
 
     extend_placeholder_schema = extend_schema(
         parameters=[
@@ -56,12 +58,27 @@ try:
             )
         ]
     )
-except ImportError:
+
+except ImportError: # pragma: no cover
     class OpenApiTypes:
         BOOL = "boolean"
         INT = "integer"
 
-    def extend_placeholder_schema(func):
+    class OpenApiParameter:  # pragma: no cover
+        QUERY = "query"
+        PATH = "path"
+        HEADER = "header"
+        COOKIE = "cookie"
+
+        def __init__(self, *args, **kwargs):
+            pass
+
+    def extend_schema(*_args, **_kwargs):  # pragma: no cover
+        def _decorator(obj: T) -> T:
+            return obj
+        return _decorator
+
+    def extend_placeholder_schema(func: Callable[P, T]) -> Callable[P, T]:
         return func
 
 

--- a/djangocms_rest/views.py
+++ b/djangocms_rest/views.py
@@ -34,7 +34,7 @@ from djangocms_rest.views_base import BaseAPIView, BaseListAPIView
 
 
 try:
-    from drf_spectacular.types import OpenApiTypes  # noqa: F401
+    from drf_spectacular.types import OpenApiTypes
     from drf_spectacular.utils import OpenApiParameter, extend_schema  # noqa: F401
 
     extend_placeholder_schema = extend_schema(
@@ -42,14 +42,24 @@ try:
             OpenApiParameter(
                 name="html",
                 type=OpenApiTypes.INT,
-                location=OpenApiParameter.QUERY,
+                location="query",
                 description="Set to 1 to include HTML rendering in response",
                 required=False,
                 enum=[1],
+            ),
+            OpenApiParameter(
+                name="preview",
+                type=OpenApiTypes.BOOL,
+                location="query",
+                description="Set to true to preview unpublished content (admin access required)",
+                required=False,
             )
         ]
     )
 except ImportError:
+    class OpenApiTypes:
+        BOOL = "boolean"
+        INT = "integer"
 
     def extend_placeholder_schema(func):
         return func
@@ -60,7 +70,7 @@ except ImportError:
 # and keeps the code cleaner.
 # Attn: Dynamic changes to the plugin pool will not be reflected in the
 # plugin definitions.
-# If you need to update the plugin definitions, you need reassign the variable.
+# If you need to update the plugin definitions, you need to reassign the variable.
 PLUGIN_DEFINITIONS = lazy(
     PluginDefinitionSerializer.generate_plugin_definitions, dict
 )()

--- a/djangocms_rest/views_base.py
+++ b/djangocms_rest/views_base.py
@@ -5,6 +5,29 @@ from rest_framework.permissions import IsAdminUser
 from rest_framework.views import APIView
 
 
+try:
+    from drf_spectacular.types import OpenApiTypes
+    from drf_spectacular.utils import OpenApiParameter, extend_schema   # noqa: F401
+
+    preview_schema = extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="preview",
+                type=OpenApiTypes.BOOL,
+                location="query",
+                description="Set to true to preview unpublished content (admin access required)",
+                required=False,
+            )
+        ]
+    )
+except ImportError:
+    class OpenApiTypes:
+        BOOL = "boolean"
+
+    def preview_schema(cls):
+        return cls
+
+@preview_schema
 class BaseAPIMixin:
     """
     This mixin provides common functionality for all API views.

--- a/djangocms_rest/views_base.py
+++ b/djangocms_rest/views_base.py
@@ -1,4 +1,4 @@
-from typing import Callable, ParamSpec, TypeVar
+from typing import ParamSpec, TypeVar
 
 from django.contrib.sites.shortcuts import get_current_site
 from django.utils.functional import cached_property

--- a/djangocms_rest/views_base.py
+++ b/djangocms_rest/views_base.py
@@ -1,13 +1,17 @@
+from typing import Callable, ParamSpec, TypeVar
+
 from django.contrib.sites.shortcuts import get_current_site
 from django.utils.functional import cached_property
 from rest_framework.generics import ListAPIView
 from rest_framework.permissions import IsAdminUser
 from rest_framework.views import APIView
 
+P = ParamSpec("P")
+T = TypeVar("T")
 
 try:
     from drf_spectacular.types import OpenApiTypes
-    from drf_spectacular.utils import OpenApiParameter, extend_schema   # noqa: F401
+    from drf_spectacular.utils import OpenApiParameter, extend_schema
 
     preview_schema = extend_schema(
         parameters=[
@@ -20,12 +24,26 @@ try:
             )
         ]
     )
-except ImportError:
+except ImportError: # pragma: no cover
     class OpenApiTypes:
         BOOL = "boolean"
 
-    def preview_schema(cls):
-        return cls
+    class OpenApiParameter:  # pragma: no cover
+        QUERY = "query"
+        PATH = "path"
+        HEADER = "header"
+        COOKIE = "cookie"
+
+        def __init__(self, *args, **kwargs):
+            pass
+
+    def extend_schema(*_args, **_kwargs):  # pragma: no cover
+        def _decorator(obj: T) -> T:
+            return obj
+        return _decorator
+
+    def preview_schema(obj: T) -> T: # pragma: no cover
+        return obj
 
 @preview_schema
 class BaseAPIMixin:

--- a/tests/requirements/base.txt
+++ b/tests/requirements/base.txt
@@ -4,6 +4,7 @@ djangocms-text
 django-filer
 beautifulsoup4
 setuptools
+drf-spectacular
 
 # other requirements
 coverage

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -34,6 +34,7 @@ INSTALLED_APPS = [
     "tests.test_app",
     "filer",
     "easy_thumbnails",
+    "drf_spectacular",
 ]
 
 MIDDLEWARE = [


### PR DESCRIPTION
- Add a preview parameter via the `@preview_schema` decorator to all views using `BaseAPIMixin`
- Add fallback `OpenApiTypes` if `drf_spectacular` is not present/installed. Needed for consistent API schema with/without swagger support.

## Summary by Sourcery

Add OpenAPI support for a "preview" query parameter across API views and ensure consistent schema generation when drf_spectacular is unavailable

New Features:
- Introduce preview_schema decorator on BaseAPIMixin to include a preview query parameter in generated schemas
- Extend existing placeholder endpoint schema in views.py with the preview query parameter

Enhancements:
- Provide fallback OpenApiTypes definitions (BOOL and INT) when drf_spectacular is not installed to maintain consistent API schema