### PR TITLE
fix: OpenAPI schema for nested navigation

### DIFF
--- a/djangocms_rest/serializers/menus.py
+++ b/djangocms_rest/serializers/menus.py
@@ -30,6 +30,7 @@ class NavigationNodeSerializer(serializers.Serializer):
     def to_representation(self, obj: NavigationNode) -> dict:
         """Customize the base representation of the NavigationNode."""
         return {
+            "namespace": getattr(obj, "namespace", None),
             "title": obj.title,
             "url": get_absolute_frontend_url(self.request, obj.url),
             "api_endpoint": get_absolute_frontend_url(
@@ -46,4 +47,4 @@ class NavigationNodeSerializer(serializers.Serializer):
 
 
 class NavigationNodeListSerializer(serializers.ListSerializer):
-    child = NavigationNodeSerializer(many=True)
+    child = NavigationNodeSerializer()

--- a/djangocms_rest/serializers/menus.py
+++ b/djangocms_rest/serializers/menus.py
@@ -46,4 +46,4 @@ class NavigationNodeSerializer(serializers.Serializer):
 
 
 class NavigationNodeListSerializer(serializers.ListSerializer):
-    child = NavigationNodeSerializer()
+    child = NavigationNodeSerializer(many=True)

--- a/djangocms_rest/views.py
+++ b/djangocms_rest/views.py
@@ -261,7 +261,7 @@ class MenuView(BaseAPIView):
         serializer = self.serializer_class(
             menu, many=True, context={"request": request}
         )
-        return Response(serializer.data)
+        return Response({self.return_key: serializer.data})
 
     def populate_defaults(self, kwargs: dict[str, Any]) -> None:
         """Set default values for menu view parameters."""

--- a/djangocms_rest/views.py
+++ b/djangocms_rest/views.py
@@ -55,11 +55,12 @@ try:
                 location="query",
                 description="Set to true to preview unpublished content (admin access required)",
                 required=False,
-            )
+            ),
         ]
     )
 
-except ImportError: # pragma: no cover
+except ImportError:  # pragma: no cover
+
     class OpenApiTypes:
         BOOL = "boolean"
         INT = "integer"
@@ -76,6 +77,7 @@ except ImportError: # pragma: no cover
     def extend_schema(*_args, **_kwargs):  # pragma: no cover
         def _decorator(obj: T) -> T:
             return obj
+
         return _decorator
 
     def extend_placeholder_schema(func: Callable[P, T]) -> Callable[P, T]:
@@ -280,8 +282,10 @@ try:
             responses=OpenApiResponse(response=NavigationNodeSerializer(many=True))
         )(method)
 except ImportError:
-    def method_schema_decorator(method):
+
+    def method_schema_decorator(method):  # pragma: no cover
         return method
+
 
 class MenuView(BaseAPIView):
     permission_classes = [IsAllowedPublicLanguage]

--- a/djangocms_rest/views.py
+++ b/djangocms_rest/views.py
@@ -281,10 +281,11 @@ try:
         return extend_schema(
             responses=OpenApiResponse(response=NavigationNodeSerializer(many=True))
         )(method)
-except ImportError:
+
+except ImportError:  # pragma: no cover
 
     def method_schema_decorator(method):  # pragma: no cover
-        return method
+        return method  # pragma: no cover
 
 
 class MenuView(BaseAPIView):


### PR DESCRIPTION
- This fixes the issue that the API can return multiple top-level nodes with children, but the schema was expecting a single object, and validation in the frontend fails. Adding a fixed response schema using `response=NavigationNodeSerializer(many=True)` fixes this issue.
- namespace is added to return as it was defined in the schema of the serializer but not returned in the view. If it is needed, it should be present in response.

## Summary by Sourcery

Enforce list response schema for nested navigation and include namespace in serializer output

Bug Fixes:
- Fix OpenAPI schema for menu view to use many=True so multiple top-level navigation nodes validate correctly
- Add namespace field to NavigationNodeSerializer representation to match its schema and return it in the view response

Enhancements:
- Introduce method_schema_decorator to conditionally apply the drf-spectacular OpenAPI response extension