### PR TITLE
fix: try to fix the issue with coverage files not uploading

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,8 +63,11 @@ jobs:
       run: |
         source .venv/bin/activate
         coverage run -m pytest
+        coverage xml
 
     - name: Upload Coverage to Codecov
       uses: codecov/codecov-action@v5.5.1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+        files: ./coverage.xml
+        fail_ci_if_error: false


### PR DESCRIPTION
## Summary by Sourcery

Generate coverage.xml and adjust Codecov upload parameters to ensure coverage reports are correctly uploaded without failing the CI.

CI:
- Add a coverage xml generation step in the test workflow
- Configure Codecov action to upload the generated coverage.xml and disable CI failure on upload errors