### PR TITLE
feat: add package data configuration for static and template files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,12 @@ include-package-data = true
 [tool.setuptools.dynamic]
 version = {attr = "djangocms_rest.__version__"}
 
+[tool.setuptools.package-data]
+djangocms_rest = [
+    "static/**",
+    "templates/**",
+]
+
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["djangocms_rest*"]


### PR DESCRIPTION
- Adds static files to the package so that they can be found by `collectstatic`. Otherwise production may fail with debug turned off and `whitenoise` enabled.