### PR TITLE
feat: Add health check endpoint and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,8 +219,9 @@ The following endpoints are available:
 | `/api/{language}/menu/...` | Fetch menu navigation (supports optional `{from_level}/{to_level}/{extra_inactive}/{extra_active}`, `{root_id}`, and `{path}` parameters) |
 | `/api/{language}/submenu/...` | Fetch submenu navigation (supports optional `{levels}`, `{root_level}`, `{nephews}`, and `{path}` parameters) |
 | `/api/{language}/breadcrumbs/...` | Fetch breadcrumb navigation (supports optional `{start_level}` and `{path}` parameters) |
+| `/api/healthcheck/` | Health check endpoint for monitoring tools |
 
-> **Documentation**  
+> **Documentation**
 > For complete endpoint documentation, request/response schemas, and authentication details, see the [API Reference](https://djangocms-rest.readthedocs.io/en/latest/reference/index.html).
 
 ### Private API (Preview)

--- a/djangocms_rest/urls.py
+++ b/djangocms_rest/urls.py
@@ -5,6 +5,7 @@ from .schemas import create_view_with_url_name
 
 
 urlpatterns = [
+    path("healthcheck/", views.HealthCheckView.as_view(), name="healthcheck"),
     # Published content endpoints
     path(
         "languages/",

--- a/djangocms_rest/views.py
+++ b/djangocms_rest/views.py
@@ -16,6 +16,7 @@ from rest_framework.exceptions import NotFound
 from rest_framework.pagination import LimitOffsetPagination
 from rest_framework.request import Request
 from rest_framework.response import Response
+from rest_framework.views import APIView
 
 from djangocms_rest.permissions import CanViewPage, IsAllowedPublicLanguage
 from djangocms_rest.serializers.languages import LanguageSerializer
@@ -41,6 +42,16 @@ from djangocms_rest.schemas import extend_placeholder_schema, extend_page_search
 # plugin definitions.
 # If you need to update the plugin definitions, you need to reassign the variable.
 PLUGIN_DEFINITIONS = lazy(PluginDefinitionSerializer.generate_plugin_definitions, dict)()
+
+
+class HealthCheckView(APIView):
+    """Minimal health check endpoint for monitoring tools."""
+
+    http_method_names = ("get", "options")
+
+    def get(self, request: Request) -> Response:
+        """Return a simple status response."""
+        return Response({"status": "ok"})
 
 
 class LanguageListView(BaseAPIView):

--- a/docs/source/reference/healthcheck.rst
+++ b/docs/source/reference/healthcheck.rst
@@ -1,0 +1,33 @@
+Healthcheck Endpoint
+====================
+
+**A minimal health check endpoint for API monitoring.**
+
+* Returns a simple status response to confirm the API is running.
+* Useful for uptime monitoring tools.
+* No authentication required.
+
+
+Endpoints
+---------
+
+Health Check
+~~~~~~~~~~~~
+
+**GET** ``/api/healthcheck/``
+
+Returns a simple status response.
+
+**Example Request:**
+
+.. code-block:: bash
+
+    GET /api/healthcheck/
+
+**Example Response:**
+
+.. code-block:: json
+
+    {
+        "status": "ok"
+    }

--- a/docs/source/reference/healthcheck.rst
+++ b/docs/source/reference/healthcheck.rst
@@ -1,4 +1,4 @@
-Healthcheck Endpoint
+Health Check Endpoint
 ====================
 
 **A minimal health check endpoint for API monitoring.**

--- a/docs/source/reference/index.rst
+++ b/docs/source/reference/index.rst
@@ -5,7 +5,7 @@ The reference section provides detailed documentation insights for all djangocms
 
 OpenAPI Documentation
 ---------------------
- We recommend to use the :doc:`../tutorial/03-openapi-documentation` guide to setup a browsable OpenAPI documentation.
+ We recommend using the :doc:`../tutorial/03-openapi-documentation` guide to set up browsable OpenAPI documentation.
  This will automatically generate the latest endpoints and their documentation.
  Furthermore with ``swagger ui`` and ``redoc`` you can test the endpoints directly in your browser.
 

--- a/docs/source/reference/index.rst
+++ b/docs/source/reference/index.rst
@@ -5,8 +5,8 @@ The reference section provides detailed documentation insights for all djangocms
 
 OpenAPI Documentation
 ---------------------
- We recommend to use the :doc:`../tutorial/03-openapi-documentation` guide to setup a browsable OpenAPI documentation. 
- This will automatically generate the latest endpoints and their documentation. 
+ We recommend to use the :doc:`../tutorial/03-openapi-documentation` guide to setup a browsable OpenAPI documentation.
+ This will automatically generate the latest endpoints and their documentation.
  Furthermore with ``swagger ui`` and ``redoc`` you can test the endpoints directly in your browser.
 
 Available Endpoints
@@ -21,3 +21,4 @@ Available Endpoints
    Submenu Endpoints <submenu>
    Breadcrumbs Endpoints <breadcrumbs>
    Plugins Endpoints <plugins>
+   Healthcheck Endpoint <healthcheck>

--- a/tests/endpoints/test_healthcheck.py
+++ b/tests/endpoints/test_healthcheck.py
@@ -1,0 +1,21 @@
+from rest_framework.reverse import reverse
+
+from tests.base import BaseCMSRestTestCase
+
+
+class HealthCheckAPITestCase(BaseCMSRestTestCase):
+    def test_get(self):
+        """
+        Test the healthcheck endpoint (/api/healthcheck/).
+
+        Verifies:
+        - Endpoint returns 200 OK
+        - Response contains status field with value "ok"
+        """
+
+        # GET
+        response = self.client.get(reverse("healthcheck"))
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+
+        self.assertEqual(data, {"status": "ok"})


### PR DESCRIPTION
fix #93 

- Add a simple API health endpoint for API uptime monitoring.
- Update documentation

## Summary by Sourcery

Add a minimal API health check endpoint and document its availability.

New Features:
- Introduce a /api/healthcheck/ endpoint that returns a simple JSON status payload for monitoring.

Documentation:
- Document the new healthcheck endpoint in the README and API reference.

Tests:
- Add an endpoint test verifying the healthcheck returns HTTP 200 and the expected JSON body.