### PR TITLE
fix: openapi endpoint naming respect user urls path

### DIFF
--- a/djangocms_rest/schemas.py
+++ b/djangocms_rest/schemas.py
@@ -15,14 +15,27 @@ try:
         """
 
         def get_operation_id(self):
-            """Override to use URL name stored in view as operation_id."""
+            """Override to use URL name stored in view as operation_id.
+
+            Derives a path prefix from the URL (via _tokenize_path) so that
+            the operation_id reflects the mount point chosen by the project
+            (e.g. ``cms_menu_retrieve`` when mounted under ``/api/cms/``).
+            """
             try:
                 url_name = getattr(self.view, "_url_name", None)
                 if not url_name and hasattr(self.view, "__class__"):
                     url_name = getattr(self.view.__class__, "_url_name", None)
 
                 if url_name:
-                    return url_name.replace("-", "_") + "_retrieve"
+                    tokenized_path = self._tokenize_path()
+                    first_name_token = url_name.split("-")[0]
+                    prefix = []
+                    for token in tokenized_path:
+                        if token.replace("-", "_") == first_name_token:
+                            break
+                        prefix.append(token.replace("-", "_"))
+                    parts = prefix + [url_name.replace("-", "_"), "retrieve"]
+                    return "_".join(parts)
 
                 # Fallback to default
                 return super().get_operation_id()

--- a/djangocms_rest/schemas.py
+++ b/djangocms_rest/schemas.py
@@ -28,12 +28,13 @@ try:
 
                 if url_name:
                     tokenized_path = self._tokenize_path()
-                    first_name_token = url_name.split("-")[0]
+                    first_name_token = url_name.split("-")[0].replace("-", "_")
                     prefix = []
                     for token in tokenized_path:
-                        if token.replace("-", "_") == first_name_token:
+                        normalized = token.replace("-", "_")
+                        if normalized == first_name_token:
                             break
-                        prefix.append(token.replace("-", "_"))
+                        prefix.append(normalized)
                     parts = prefix + [url_name.replace("-", "_"), "retrieve"]
                     return "_".join(parts)
 

--- a/djangocms_rest/schemas.py
+++ b/djangocms_rest/schemas.py
@@ -37,6 +37,8 @@ try:
                                 break
                             prefix.append(normalized)
                     except (AttributeError, TypeError):
+                        # _tokenize_path requires path/path_prefix attributes
+                        # that may be absent outside drf-spectacular's request cycle.
                         pass
                     parts = prefix + [url_name.replace("-", "_"), "retrieve"]
                     return "_".join(parts)

--- a/djangocms_rest/schemas.py
+++ b/djangocms_rest/schemas.py
@@ -27,14 +27,17 @@ try:
                     url_name = getattr(self.view.__class__, "_url_name", None)
 
                 if url_name:
-                    tokenized_path = self._tokenize_path()
-                    first_name_token = url_name.split("-")[0].replace("-", "_")
                     prefix = []
-                    for token in tokenized_path:
-                        normalized = token.replace("-", "_")
-                        if normalized == first_name_token:
-                            break
-                        prefix.append(normalized)
+                    try:
+                        tokenized_path = self._tokenize_path()
+                        first_name_token = url_name.split("-")[0].replace("-", "_")
+                        for token in tokenized_path:
+                            normalized = token.replace("-", "_")
+                            if normalized == first_name_token:
+                                break
+                            prefix.append(normalized)
+                    except (AttributeError, TypeError):
+                        pass
                     parts = prefix + [url_name.replace("-", "_"), "retrieve"]
                     return "_".join(parts)
 

--- a/djangocms_rest/urls.py
+++ b/djangocms_rest/urls.py
@@ -23,12 +23,12 @@ urlpatterns = [
     ),
     path(
         "<slug:language>/pages/",
-        views.PageDetailView.as_view(),
+        create_view_with_url_name(views.PageDetailView, "page-root"),
         name="page-root",
     ),
     path(
         "<slug:language>/pages/<path:path>/",
-        views.PageDetailView.as_view(),
+        create_view_with_url_name(views.PageDetailView, "page-detail"),
         name="page-detail",
     ),
     path(

--- a/djangocms_rest/views.py
+++ b/djangocms_rest/views.py
@@ -127,6 +127,7 @@ class PageTreeListView(BaseAPIView):
         return Response(serializer.data)
 
 
+@menu_schema_class
 class PageDetailView(BaseAPIView):
     permission_classes = [IsAllowedPublicLanguage, CanViewPage]
     serializer_class = PageContentSerializer

--- a/tests/test_openapi_schema.py
+++ b/tests/test_openapi_schema.py
@@ -302,6 +302,28 @@ class OpenAPISchemaTestCase(RESTTestCase):
         # Clean up
         delattr(view_instance.__class__, "_url_name")
 
+    def test_menu_schema_get_operation_id_includes_path_prefix(self):
+        """Test MenuSchema.get_operation_id includes URL path prefix in operation_id."""
+        import djangocms_rest.schemas
+        from djangocms_rest.views import MenuView
+
+        view_instance = MenuView()
+        view_instance._url_name = "menu-levels"
+
+        schema = djangocms_rest.schemas.MenuSchema()
+        schema.view = view_instance
+        schema.path = "/api/cms/{language}/menu/{from_level}/{to_level}/{extra_inactive}/{extra_active}/"
+        schema.path_prefix = "/api/"
+
+        operation_id = schema.get_operation_id()
+        self.assertEqual(operation_id, "cms_menu_levels_retrieve")
+
+        # When url_name token is not found in path, all tokens become prefix
+        view_instance._url_name = "custom-endpoint"
+        schema.path = "/api/cms/"
+        operation_id = schema.get_operation_id()
+        self.assertEqual(operation_id, "cms_custom_endpoint_retrieve")
+
     def test_menu_schema_get_operation_id_fallback_when_no_url_name(self):
         """Test MenuSchema.get_operation_id falls back to default when _url_name is not set."""
         import djangocms_rest.schemas


### PR DESCRIPTION
fix #82 

- OpenAPI schema respects custom user URLs when customizing/nesting REST endpoints.

## Summary by Sourcery

Bug Fixes:
- Ensure generated OpenAPI operation IDs for menu endpoints respect custom or nested URL paths instead of using a fixed suffix.