### PR TITLE
feat/expose-parent_plugin_type-and-id

### DIFF
--- a/djangocms_rest/serializers/plugins.py
+++ b/djangocms_rest/serializers/plugins.py
@@ -99,7 +99,6 @@ def serialize_soft_refs(request: HttpRequest, data: Any) -> Any:
 
 
 base_exclude = {
-    "id",
     "placeholder",
     "language",
     "position",
@@ -117,9 +116,15 @@ JSON_FIELDS = tuple(
 
 
 class GenericPluginSerializer(serializers.ModelSerializer):
+    parent_plugin_type = serializers.SerializerMethodField()
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.request = self.context.get("request", None)
+
+    def get_parent_plugin_type(self, obj) -> str | None:
+        parent = obj.parent
+        return parent.plugin_type if parent else None
 
     def to_representation(self, instance: CMSPlugin):
         request = getattr(self, "request", None)

--- a/tests/endpoints/test_placeholders.py
+++ b/tests/endpoints/test_placeholders.py
@@ -58,7 +58,9 @@ class PlaceholdersAPITestCase(BaseCMSRestTestCase):
         type_checks = PLACEHOLDER_FIELD_TYPES
 
         plugin_type_checks = {
+            "id": int,
             "plugin_type": str,
+            "parent_plugin_type": (str, type(None)),
             "body": str,
             "json": dict,
             "rte": str,

--- a/tests/endpoints/test_plugin_list.py
+++ b/tests/endpoints/test_plugin_list.py
@@ -20,6 +20,7 @@ class PluginListTestCase(BaseCMSRestTestCase):
             "title": "Dummy Number Plugin",
             "type": "object",
             "properties": {
+                "id": {"type": "integer"},
                 "integer": {"type": "integer"},
                 "json": {"type": "object"},
                 "float": {"type": "number"},


### PR DESCRIPTION
**- expose parent_plugin_type**
Allows context-based plugin rendering, different rendering depending on the child plugin location.

**- expose id**
Allows target of edit functionality via id in Django CMS 
We could make id dependent on ?preview=true, but does exposing ID really open up security issues?

I would like to see this PR as part of djangocms-rest as it allows better frontend tooling for editing and layout. 

## Summary by Sourcery

Expose additional plugin context fields in the plugin serializer response.

New Features:
- Include the plugin instance id in serialized plugin responses to support direct targeting in consumers.
- Expose parent_plugin_type on serialized plugins to enable context-based rendering depending on the plugin hierarchy.

Tests:
- Extend endpoint tests to assert presence and types of id and parent_plugin_type in plugin and placeholder API responses.