### PR TITLE
fix: update PluginDefinitionSerializer

### DIFF
--- a/djangocms_rest/serializers/plugins.py
+++ b/djangocms_rest/serializers/plugins.py
@@ -191,7 +191,7 @@ class PluginDefinitionSerializer(serializers.Serializer):
         definitions = {}
 
         for plugin in plugin_pool.plugins.values():
-            # Fall back to Generic            # Fall back to GenericPluginSerializer to match the runtime auto-serializer.PluginSerializer to match the runtime auto-serializer.
+            #Fall back to GenericPluginSerializer to match the runtime auto-serializer.
             serializer_cls = getattr(plugin, "serializer_class", None)
 
             if not serializer_cls:

--- a/djangocms_rest/serializers/plugins.py
+++ b/djangocms_rest/serializers/plugins.py
@@ -191,15 +191,17 @@ class PluginDefinitionSerializer(serializers.Serializer):
         definitions = {}
 
         for plugin in plugin_pool.plugins.values():
-            # Use plugin's serializer_class or create a simple fallback
+            # Fall back to Generic            # Fall back to GenericPluginSerializer to match the runtime auto-serializer.PluginSerializer to match the runtime auto-serializer.
             serializer_cls = getattr(plugin, "serializer_class", None)
 
             if not serializer_cls:
+                real_fields = {f.name for f in plugin.model._meta.get_fields()}
+                plugin_exclude = tuple(base_exclude & real_fields)
 
-                class DynamicModelSerializer(serializers.ModelSerializer):
+                class DynamicModelSerializer(GenericPluginSerializer):
                     class Meta:
                         model = plugin.model
-                        fields = "__all__"
+                        exclude = plugin_exclude
 
                 serializer_cls = DynamicModelSerializer
 

--- a/tests/endpoints/test_plugin_list.py
+++ b/tests/endpoints/test_plugin_list.py
@@ -73,4 +73,7 @@ class PluginListTestCase(BaseCMSRestTestCase):
             ),
             None,
         )
+        self.assertIsNotNone(dummy_plugin, "DummyNumberPlugin not found in response")
+        # "position" is a base_exclude member and must be skipped from the schema.
+        self.assertNotIn("position", dummy_plugin["properties"])
         self.assertDictEqual(dummy_plugin, expected_dummy_plugin_signature)

--- a/tests/test_app/serializers.py
+++ b/tests/test_app/serializers.py
@@ -10,6 +10,8 @@ class CustomSerializer(serializers.Serializer):
         default="title",
     )
     json = serializers.JSONField()
+    # Exercises base_exclude skip in schema generation; see test_plugin_list.
+    position = serializers.IntegerField(default=0)
 
     class KeyValuePairSerializer(serializers.Serializer):
         prop1 = serializers.CharField()


### PR DESCRIPTION
Problem:
- Text-Plugin correctly returns serialized data, but it did not match the schema (missing parent_plugin_type). 

Solution:
- Add GenericPluginSerializer support on PluginDefinitionSerializer
- This allows schemas of plugins to properly use all fields defined in GenericPluginSerializer.

## Summary by Sourcery

Align plugin definition serialization with the generic plugin schema to fix mismatches between runtime data and defined fields.

Bug Fixes:
- Ensure dynamically generated plugin serializers include all fields defined by GenericPluginSerializer so plugin schemas match runtime serialization.

Enhancements:
- Update fallback plugin serializer generation to derive from GenericPluginSerializer and exclude only applicable base fields for each plugin model.