### PR TITLE
tests: Accept oneOf scheme in tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,8 @@ jobs:
           dj51_cms50.txt,
           dj52_cms50.txt,
           dj60_cms50.txt,
+          dj52_cms51.txt,
+          dj60_cms51.txt,
           dj52_cmsmain.txt
         ]
         os: [
@@ -26,6 +28,10 @@ jobs:
             requirements-file: dj60_cms50.txt
           - python-version: "3.11"
             requirements-file: dj60_cms50.txt
+          - python-version: "3.10"
+            requirements-file: dj60_cms51.txt
+          - python-version: "3.11"
+            requirements-file: dj60_cms51.txt
           - python-version: "3.14"
             requirements-file: dj42_cms41.txt
             os: ubuntu-latest

--- a/tests/requirements/dj52_cms51.txt
+++ b/tests/requirements/dj52_cms51.txt
@@ -1,0 +1,4 @@
+-r base.txt
+
+Django>=5.2,<5.3
+django-cms>=5.1,<5.2

--- a/tests/requirements/dj60_cms51.txt
+++ b/tests/requirements/dj60_cms51.txt
@@ -1,0 +1,4 @@
+-r base.txt
+
+Django>=6.0,<6.1
+django-cms>=5.1,<5.2

--- a/tests/test_openapi_schema.py
+++ b/tests/test_openapi_schema.py
@@ -148,6 +148,7 @@ class OpenAPISchemaTestCase(RESTTestCase):
                             and "$ref" not in prop_def
                             and "allOf" not in prop_def
                             and "anyOf" not in prop_def
+                            and "oneOf" not in prop_def
                         ):
                             errors.append(
                                 f"Schema '{schema_name}' property '{prop_name}' has no type or reference defined"


### PR DESCRIPTION
## Summary by Sourcery

Tests:
- Update OpenAPI schema structure test to accept properties that use a oneOf definition instead of requiring a type or reference.